### PR TITLE
Indexing fixes

### DIFF
--- a/tomviz/python/AutoCrossCorrelationTiltImageAlignment.py
+++ b/tomviz/python/AutoCrossCorrelationTiltImageAlignment.py
@@ -66,6 +66,12 @@ class CrossCorrelationAlignmentOperator(tomviz.operators.CancelableOperator):
 
         utils.set_array(dataset, tiltSeries)
 
+        # Assign Negative Shifts when Shift > N/2.
+        max_indeces_X = np.where(offsets > tiltSeries.shape[0] / 2)
+        offsets[max_indeces_X] = offsets[max_indeces_X] - tiltSeries.shape[0]
+        max_indeces_Y = np.where(offsets > tiltSeries.shape[1] / 2)
+        offsets[max_indeces_Y] = offsets[max_indeces_Y] - tiltSeries.shape[1]
+
         # Create a spreadsheet data set from table data
         column_names = ["X Offset", "Y Offset"]
         offsetsTable = utils.make_spreadsheet(column_names, offsets)

--- a/tomviz/python/AutoCrossCorrelationTiltImageAlignment.py
+++ b/tomviz/python/AutoCrossCorrelationTiltImageAlignment.py
@@ -67,10 +67,10 @@ class CrossCorrelationAlignmentOperator(tomviz.operators.CancelableOperator):
         utils.set_array(dataset, tiltSeries)
 
         # Assign Negative Shifts when Shift > N/2.
-        max_indeces_X = np.where(offsets > tiltSeries.shape[0] / 2)
-        offsets[max_indeces_X] = offsets[max_indeces_X] - tiltSeries.shape[0]
-        max_indeces_Y = np.where(offsets > tiltSeries.shape[1] / 2)
-        offsets[max_indeces_Y] = offsets[max_indeces_Y] - tiltSeries.shape[1]
+        max_indeces_X = np.where(offsets[:, 0] > tiltSeries.shape[0] / 2)
+        offsets[max_indeces_X, 0] -= tiltSeries.shape[0]
+        max_indeces_Y = np.where(offsets[:, 1] > tiltSeries.shape[1] / 2)
+        offsets[max_indeces_Y, 1] -= tiltSeries.shape[1]
 
         # Create a spreadsheet data set from table data
         column_names = ["X Offset", "Y Offset"]


### PR DESCRIPTION
@jtschwar Here is a fix for the indexing issues I'm trying to describe.  Do you understand what I changed and why I changed it?

* changed the where to search only the column of interest: `offsets` -> `offsets[:, 0]`.  This gives the rows where the condition is true for the X column instead of all locations in the table where it is true.  Alternatively we could filter max_indeces_X to select only the ones where the column is what we want.

* changed to use `-=` instead of repeating what to set (style, not functionality)

* changed to only set the column of interest `offsets[max_indeces_X]` -> `offsets[max_indeces_X, 0]`.  So this only sets the X column.  This is needed since we only get row numbers from the where clause now.